### PR TITLE
Celery stuck by healthcheck.

### DIFF
--- a/ovs/extensions/healthcheck/utils/extension.py
+++ b/ovs/extensions/healthcheck/utils/extension.py
@@ -51,6 +51,7 @@ class Utils:
     """
     General utilities for Open vStorage healthcheck
     """
+    SETTINGS_LOC = "/opt/OpenvStorage/config/healthcheck/settings.json"
 
     def __init__(self):
         """ Init method """
@@ -59,8 +60,7 @@ class Utils:
         self.module = "utils"
 
         # load config file
-        self.settings_loc = "/opt/OpenvStorage/config/healthcheck/settings.json"
-        with open(self.settings_loc) as settings_file:
+        with open(self.SETTINGS_LOC) as settings_file:
             self.settings = json.load(settings_file)
 
         # fetch from config file
@@ -289,3 +289,5 @@ class Utils:
             return 1
         else:
             raise RuntimeError("Unsupported Service Manager detected, please contact support or file a bug @github")
+
+

--- a/ovs/log/healthcheck_logHandler.py
+++ b/ovs/log/healthcheck_logHandler.py
@@ -65,7 +65,7 @@ class HCLogHandler:
         self.module = "utils"
 
         # load config file
-        with open(Utils().settings_loc) as settings_file:
+        with open(Utils.SETTINGS_LOC) as settings_file:
             self.settings = json.load(settings_file)
 
         # fetch from config file


### PR DESCRIPTION
When creating a SSHClient on module load time, Celery was not booting anymore.
Fixed this by creating a global setting on the extension.py.

reinstalling env, searching issue, fixing (1d)