### PR TITLE
Use the ovs standard log format

### DIFF
--- a/config/healthcheck/settings.json
+++ b/config/healthcheck/settings.json
@@ -2,9 +2,7 @@
     "healthcheck": {
         "library": "/opt/OpenvStorage",
         "logging": {
-            "enable": false,
-            "directory": "/var/log/ovs",
-            "file": "healthcheck.log"
+            "enable": false
         },
         "debug_mode": false,
         "max_check_log_size": 500

--- a/ovs/extensions/healthcheck/alba/alba_health_check.py
+++ b/ovs/extensions/healthcheck/alba/alba_health_check.py
@@ -105,7 +105,7 @@ class AlbaHealthCheck:
 
         amount_of_presets_not_working = []
 
-        self.LOGGER.logger("Checking seperate proxies to see if they work ...", self.module, 3, 'checkAlba', False)
+        self.LOGGER.info("Checking seperate proxies to see if they work ...", 'checkAlba', False)
 
         # ignore possible subprocess output
         fnull = open(os.devnull, 'w')
@@ -148,11 +148,11 @@ class AlbaHealthCheck:
                             if json_nam['success']:
 
                                 # get & put is successfully executed
-                                self.LOGGER.logger("Namespace successfully created or already existed "
-                                                   "via proxy '{0}' ""with preset '{1}'!".format(sr.name,
-                                                                                                 preset.get('name')),
-                                                   self.module, 1, '{0}_preset_{1}_create_namespace'
-                                                   .format(sr.name, preset.get('name')))
+                                self.LOGGER.success("Namespace successfully created or already existed "
+                                                    "via proxy '{0}' ""with preset '{1}'!".format(sr.name,
+                                                                                                  preset.get('name')),
+                                                    '{0}_preset_{1}_create_namespace'
+                                                    .format(sr.name, preset.get('name')))
 
                                 # put test object to given dir
                                 with open(self.temp_file_loc, 'wb') as fout:
@@ -176,21 +176,21 @@ class AlbaHealthCheck:
                                                                .read()).hexdigest()
 
                                     if hash_original == hash_fetched:
-                                        self.LOGGER.logger("Creation of a object in namespace '{0}' on proxy '{1}' "
-                                                           "with preset '{2}' succeeded!".format(namespace_key,
-                                                                                                 sr.name,
-                                                                                                 preset.get('name')),
-                                                           self.module, 1, '{0}_preset_{1}_create_object'
-                                                           .format(sr.name, preset.get('name')))
+                                        self.LOGGER.success("Creation of a object in namespace '{0}' on proxy '{1}' "
+                                                            "with preset '{2}' succeeded!".format(namespace_key,
+                                                                                                  sr.name,
+                                                                                                  preset.get('name')),
+                                                            '{0}_preset_{1}_create_object'
+                                                            .format(sr.name, preset.get('name')))
                                     else:
-                                        self.LOGGER.logger("Creation of a object '{0}' in namespace '{1}' on proxy"
-                                                           " '{2}' with preset '{3}' failed!".format(object_key,
-                                                                                                     namespace_key,
-                                                                                                     sr.name,
-                                                                                                     preset.get('name')
-                                                                                                     ),
-                                                           self.module, 0, '{0}_preset_{1}_create_object'
-                                                           .format(sr.name, preset.get('name')))
+                                        self.LOGGER.failure("Creation of a object '{0}' in namespace '{1}' on proxy"
+                                                            " '{2}' with preset '{3}' failed!".format(object_key,
+                                                                                                      namespace_key,
+                                                                                                      sr.name,
+                                                                                                      preset.get('name')
+                                                                                                      ),
+                                                            '{0}_preset_{1}_create_object'
+                                                            .format(sr.name, preset.get('name')))
 
                                 else:
                                     # creation of object failed
@@ -205,28 +205,27 @@ class AlbaHealthCheck:
 
                             if 'not found' in get_nam:
                                 # put was not successfully executed, so get return success = False
-                                self.LOGGER.logger("Creating/fetching namespace '{0}' with preset '{1}' on proxy '{2}'"
-                                                   " failed! ".format(namespace_key, preset.get('name'), sr.name),
-                                                   self.module, 0, '{0}_preset_{1}_create_namespace'
-                                                   .format(sr.name, preset.get('name')))
+                                self.LOGGER.failure("Creating/fetching namespace '{0}' with preset '{1}' on proxy '{2}'"
+                                                    " failed! ".format(namespace_key, preset.get('name'), sr.name),
+                                                    '{0}_preset_{1}_create_namespace'
+                                                    .format(sr.name, preset.get('name')))
 
                                 # for unattended install
-                                self.LOGGER.logger("Failed to put object because namespace failed to be "
-                                                   "created/fetched on proxy '{0}'! ".format(sr.name), self.module,
-                                                   0, '{0}_preset_{1}_create_object'.format(sr.name, preset.get('name'))
-                                                   )
+                                self.LOGGER.failure("Failed to put object because namespace failed to be "
+                                                    "created/fetched on proxy '{0}'! ".format(sr.name),
+                                                    '{0}_preset_{1}_create_object'.format(sr.name, preset.get('name')))
                             else:
                                 # for unattended install
-                                self.LOGGER.logger("Failed to put object on namespace '{0}' failed on proxy"
-                                                   "'{0}'! ".format(sr.name), self.module, 0,
-                                                   '{0}_preset_{1}_create_object'.format(sr.name, preset.get('name')))
+                                self.LOGGER.failure("Failed to put object on namespace '{0}' failed on proxy"
+                                                    "'{0}'! ".format(sr.name),
+                                                    '{0}_preset_{1}_create_object'.format(sr.name, preset.get('name')))
 
                         except Exception as e:
                             amount_of_presets_not_working.append(preset.get('name'))
 
-                            self.LOGGER.logger("Something unexpected went wrong during the check of the alba"
-                                               " proxies: {0}".format(e), self.module, 4,
-                                               '{0}_preset_{1}_create_object'.format(sr.name, preset.get('name')))
+                            self.LOGGER.exception("Something unexpected went wrong during the check of the alba"
+                                                  " proxies: {0}".format(e),
+                                                  '{0}_preset_{1}_create_object'.format(sr.name, preset.get('name')))
 
                         # clean-up procedure for created object(s) & temp. files
                         subprocess.call(['alba', 'delete-object', '--config', str(abm_config),
@@ -254,7 +253,8 @@ class AlbaHealthCheck:
         workingdisks = []
         defectivedisks = []
 
-        self.LOGGER.logger("Checking seperate ASD's for backend '{0}' to see if they work ...".format(backend_name), self.module, 3, 'checkAsds', False)
+        self.LOGGER.info("Checking seperate ASD's for backend '{0}' to see if they work ...".format(backend_name),
+                         'checkAsds', False)
 
         # check if disks are working
         if len(disks) != 0:
@@ -285,9 +285,9 @@ class AlbaHealthCheck:
                             raise Exception(g)
                         else:
                             # test successfull!
-                            self.LOGGER.logger("ASD test with DISK_ID '{0}' succeeded!".format(disk.get('asd_id')),
-                                               self.module, 1, 'alba_asd_{0}'.format(disk.get('asd_id')),
-                                               self.show_disks_in_monitoring)
+                            self.LOGGER.success("ASD test with DISK_ID '{0}' succeeded!".format(disk.get('asd_id')),
+                                                'alba_asd_{0}'.format(disk.get('asd_id')),
+                                                self.show_disks_in_monitoring)
 
                             workingdisks.append(disk.get('asd_id'))
 
@@ -300,9 +300,9 @@ class AlbaHealthCheck:
 
                 except Exception as e:
                     defectivedisks.append(disk.get('asd_id'))
-                    self.LOGGER.logger("ASD test with DISK_ID '{0}' failed on NODE '{1}' with exception: {2}"
-                                       .format(disk.get('asd_id'), ip_address, e), self.module, 0,
-                                       'alba_asd_{0}'.format(disk.get('asd_id')), self.show_disks_in_monitoring)
+                    self.LOGGER.failure("ASD test with DISK_ID '{0}' failed on NODE '{1}' with exception: {2}"
+                                        .format(disk.get('asd_id'), ip_address, e),
+                                        'alba_asd_{0}'.format(disk.get('asd_id')), self.show_disks_in_monitoring)
 
         return workingdisks, defectivedisks
 
@@ -311,24 +311,24 @@ class AlbaHealthCheck:
         Checks Alba as a whole
         """
 
-        self.LOGGER.logger("Fetching all Available ALBA backends ...", self.module, 3, 'checkAlba', False)
+        self.LOGGER.info("Fetching all Available ALBA backends ...", 'checkAlba', False)
         try:
             alba_backends = self._fetch_available_backends()
 
             if len(alba_backends) != 0:
-                self.LOGGER.logger("We found {0} backend(s)!".format(len(alba_backends)), self.module, 1,
-                                   'alba_backends_found'.format(len(alba_backends)))
+                self.LOGGER.success("We found {0} backend(s)!".format(len(alba_backends)),
+                                    'alba_backends_found'.format(len(alba_backends)))
                 for backend in alba_backends:
 
                     # check proxies, and recap for unattended
                     result_proxies = self._check_if_proxies_work()
                     if len(result_proxies) == 0:
                         # all proxies work
-                        self.LOGGER.logger("All Alba proxies should be fine!", self.module, 1, 'alba_proxy')
+                        self.LOGGER.success("All Alba proxies should be fine!", 'alba_proxy')
                     else:
                         # not all proxies work
-                        self.LOGGER.logger("Some alba proxies are NOT working: {0}".format(', '.join(result_proxies)),
-                                           self.module, 0, 'alba_proxy')
+                        self.LOGGER.failure("Some alba proxies are NOT working: {0}".format(', '.join(result_proxies)),
+                                            'alba_proxy')
 
                     # check disks
                     result_disks = self._check_backend_asds(backend.get('all_disks'), backend.get('name'))
@@ -338,33 +338,32 @@ class AlbaHealthCheck:
                     # check if backend is available for vPOOL attachment / use
                     if backend.get('is_available_for_vpool'):
                         if len(defectivedisks) == 0:
-                            self.LOGGER.logger("Alba backend '{0}' should be AVAILABLE FOR vPOOL USE,"
-                                               " ALL disks are working fine!".format(backend.get('name')),
-                                               self.module, 1, 'alba_backend_{0}'.format(backend.get('name')))
+                            self.LOGGER.success("Alba backend '{0}' should be AVAILABLE FOR vPOOL USE,"
+                                                " ALL disks are working fine!".format(backend.get('name')),
+                                                'alba_backend_{0}'.format(backend.get('name')))
                         else:
-                            self.LOGGER.logger("Alba backend '{0}' should be AVAILABLE FOR vPOOL USE with {1} disks,"
-                                               " BUT there are {2} defective disks: {3}".format(backend.get('name'),
-                                                                                                len(workingdisks),
-                                                                                                len(defectivedisks),
-                                                                                                ', '.join(defectivedisks
-                                                                                                          )),
-                                               self.module, 2, 'alba_backend_{0}'.format(backend.get('name'),
-                                                                                         len(defectivedisks)))
+                            self.LOGGER.warning("Alba backend '{0}' should be AVAILABLE FOR vPOOL USE with {1} disks,"
+                                                " BUT there are {2} defective disks: {3}".format(backend.get('name'),
+                                                                                                 len(workingdisks),
+                                                                                                 len(defectivedisks),
+                                                                                                 ', '.join(
+                                                                                                     defectivedisks)),
+                                                'alba_backend_{0}'.format(backend.get('name'), len(defectivedisks)))
                     else:
                         if len(workingdisks) == 0 and len(defectivedisks) == 0:
-                            self.LOGGER.logger("Alba backend '{0}' is NOT available for vPool use, there are no"
-                                               " disks assigned to this backend!".format(backend.get('name')),
-                                               self.module, 5, 'alba_backend_{0}'.format(backend.get('name')))
+                            self.LOGGER.skip("Alba backend '{0}' is NOT available for vPool use, there are no"
+                                             " disks assigned to this backend!".format(backend.get('name')),
+                                             'alba_backend_{0}'.format(backend.get('name')))
                         else:
-                            self.LOGGER.logger("Alba backend '{0}' is NOT available for vPool use, preset"
-                                               " requirements NOT SATISFIED! There are {1} working disks AND {2}"
-                                               " defective disks!".format(backend.get('name'), len(workingdisks),
-                                                                          len(defectivedisks)), self.module, 0,
-                                               'alba_backend_{0}'.format(backend.get('name')))
+                            self.LOGGER.failure("Alba backend '{0}' is NOT available for vPool use, preset"
+                                                " requirements NOT SATISFIED! There are {1} working disks AND {2}"
+                                                " defective disks!".format(backend.get('name'), len(workingdisks),
+                                                                           len(defectivedisks)),
+                                                'alba_backend_{0}'.format(backend.get('name')))
 
             else:
-                self.LOGGER.logger("No backends found ...", self.module, 5, 'alba_backends_found')
+                self.LOGGER.skip("No backends found ...", 'alba_backends_found')
             return None
         except Exception as e:
-            self.LOGGER.logger("One ore more Arakoon clusters cannot be reached due to error: {0}".format(e),
-                               self.module, 0, 'arakoon_connected', False)
+            self.LOGGER.failure("One ore more Arakoon clusters cannot be reached due to error: {0}".format(e),
+                                'arakoon_connected', False)

--- a/ovs/extensions/healthcheck/openvstorage/openvstoragecluster_health_check.py
+++ b/ovs/extensions/healthcheck/openvstorage/openvstoragecluster_health_check.py
@@ -42,6 +42,7 @@ from ovs.log.healthcheck_logHandler import HCLogHandler
 import volumedriver.storagerouter.storagerouterclient as src
 from volumedriver.storagerouter.storagerouterclient import MaxRedirectsExceededException
 
+
 class OpenvStorageHealthCheck:
     """
     A healthcheck for the Open vStorage framework
@@ -55,8 +56,7 @@ class OpenvStorageHealthCheck:
 
         @type logging: Class
         """
-
-        self.module = 'openvstorage'
+        self.module = "openvstorage"
         self.LOGGER = logging
         self.utility = Utils()
         self.service_manager = self.utility.serviceManager
@@ -114,11 +114,11 @@ class OpenvStorageHealthCheck:
         Fetch settings of the local Open vStorage node
         """
 
-        self.LOGGER.logger("Fetching LOCAL information of node: ", self.module, 3, 'local_info', False)
-        self.LOGGER.logger("Cluster ID: {0}".format(self.utility.cluster_id), self.module, 1, 'lc2', False)
-        self.LOGGER.logger("Storagerouter ID: {0}".format(self.machine_id), self.module, 1, 'lc2', False)
-        self.LOGGER.logger("Environment TYPE: {0}".format(self.machine_details.node_type), self.module, 1, 'lc3', False)
-        self.LOGGER.logger("Environment VERSION: {0}".format(self.utility.ovs_version), self.module, 1, 'lc4', False)
+        self.LOGGER.info("Fetching LOCAL information of node: ", 'local_info', False)
+        self.LOGGER.success("Cluster ID: {0}".format(self.utility.cluster_id), 'lc2', False)
+        self.LOGGER.success("Storagerouter ID: {0}".format(self.machine_id), 'lc2', False)
+        self.LOGGER.success("Environment TYPE: {0}".format(self.machine_details.node_type), 'lc3', False)
+        self.LOGGER.success("Environment VERSION: {0}".format(self.utility.ovs_version), 'lc4', False)
 
     def check_size_of_log_files(self):
         """
@@ -129,8 +129,8 @@ class OpenvStorageHealthCheck:
         good_size = []
         to_big = []
 
-        self.LOGGER.logger("Checking if logfiles their size is not bigger than {0} MB: ".format(self.max_logsize),
-                           self.module, 3, 'checkLogfilesSize', False)
+        self.LOGGER.info("Checking if logfiles their size is not bigger than {0} MB: ".format(self.max_logsize),
+                         'checkLogfilesSize', False)
 
         # collect log files
         for log, settings in self.logging.iteritems():
@@ -174,20 +174,20 @@ class OpenvStorageHealthCheck:
             # check if logfile is larger than max_size
             if os.stat(c_files).st_size < 1024000 * self.max_logsize:
                 good_size.append(c_files)
-                self.LOGGER.logger("Logfile '{0}' has a GOOD size!".format(c_files), self.module, 1,
-                                   'log_{0}'.format(c_files), False)
+                self.LOGGER.success("Logfile '{0}' has a GOOD size!".format(c_files), 'log_{0}'.format(c_files),
+                                    False)
             else:
                 to_big.append(c_files)
-                self.LOGGER.logger("Logfile '{0}' is a big ass logfile!".format(c_files), self.module, 0,
-                                   'log_{0}'.format(c_files), False)
+                self.LOGGER.failure("Logfile '{0}' is a big ass logfile!".format(c_files), 'log_{0}'.format(c_files),
+                                    False)
 
         # end for unattended_install
         if self.LOGGER.unattended_mode:
             if len(to_big) != 0:
-                self.LOGGER.logger("Some logfiles are too big, please check this!".format(c_files),
-                                   self.module, 0, 'log_size')
+                self.LOGGER.failure("Some logfiles are too big, please check this!".format(c_files),
+                                    'log_size')
             else:
-                self.LOGGER.logger("ALL log files are ok!".format(c_files), self.module, 1, 'log_size')
+                self.LOGGER.success("ALL log files are ok!".format(c_files), 'log_size')
 
     @staticmethod
     def _list_logs_in_directory(pwd):
@@ -226,8 +226,8 @@ class OpenvStorageHealthCheck:
         Check if Open vStorage is connected to a certain Hypervisor management center (e.g. VMware vCenter or Openstack)
         """
 
-        self.LOGGER.logger("Checking if OVS is connected to any OpenStack or VMWare Management centers ...",
-                           self.module, 3, 'checkHypervisorManagementInformation', False)
+        self.LOGGER.info("Checking if OVS is connected to any OpenStack or VMWare Management centers ...",
+                         'checkHypervisorManagementInformation', False)
         management_centers = MgmtCenterList().get_mgmtcenters()
 
         # get available openstack/vmware management centers
@@ -235,18 +235,17 @@ class OpenvStorageHealthCheck:
             for center in management_centers:
 
                 # get general management center information
-                self.LOGGER.logger("OVS is connected to: {0}".format(center.type), self.module, 1,
-                                   'manc_ovs_connected'.format(center.type), False)
-                self.LOGGER.logger("Name: {0}".format(center.name), self.module, 1, 'manc_name_{0}'
-                                   .format(center.name), False)
-                self.LOGGER.logger("IP-address: {0}:{1}".format(center.ip, center.port), self.module, 1,
-                                   'manc_ip_{0}_{1}'.format(center.ip, center.port), False)
-                self.LOGGER.logger("user: {0}".format(center.username), self.module, 1, 'manc_user_{0}'
-                                   .format(center.username), False)
+                self.LOGGER.success("OVS is connected to: {0}".format(center.type),
+                                    'manc_ovs_connected'.format(center.type), False)
+                self.LOGGER.success("Name: {0}".format(center.name),
+                                    'manc_name_{0}'.format(center.name), False)
+                self.LOGGER.success("IP-address: {0}:{1}".format(center.ip, center.port),
+                                    'manc_ip_{0}_{1}'.format(center.ip, center.port), False)
+                self.LOGGER.success("user: {0}".format(center.username),
+                                    'manc_user_{0}'.format(center.username), False)
 
         else:
-            self.LOGGER.logger("No OpenStack/VMWare management center connected!", self.module, 5,
-                               'manc_ovs_connected')
+            self.LOGGER.skip("No OpenStack/VMWare management center connected!", 'manc_ovs_connected')
 
     @staticmethod
     def _fetch_compute_node_details_by_ip(node_ip):
@@ -317,67 +316,65 @@ class OpenvStorageHealthCheck:
         @type port: int
         """
 
-        self.LOGGER.logger("Checking port {0} of service {1} ...".format(port, process_name), self.module, 3,
-                           '_is_port_listening', False)
+        self.LOGGER.info("Checking port {0} of service {1} ...".format(port, process_name), '_is_port_listening', False)
         if self._check_port_connection(port):
-            self.LOGGER.logger("Connection successfully established!", self.module, 1, 'port_{0}_{1}'
-                               .format(process_name, port))
+            self.LOGGER.success("Connection successfully established!",
+                                'port_{0}_{1}'.format(process_name, port))
         else:
-            self.LOGGER.logger("Connection FAILED to service '{1}' on port {0}".format(port, process_name),
-                               self.module, 0, 'port_{0}_{1}'.format(process_name, port))
+            self.LOGGER.failure("Connection FAILED to service '{1}' on port {0}".format(port, process_name),
+                                'port_{0}_{1}'.format(process_name, port))
 
     def check_required_ports(self):
         """
         Checks all ports of Open vStorage components (framework, memcached, nginx, rabbitMQ and celery)
         """
 
-        self.LOGGER.logger("Checking PORT CONNECTIONS of several services ...", self.module, 3,
-                           'check_required_ports', False)
+        self.LOGGER.info("Checking PORT CONNECTIONS of several services ...", 'check_required_ports', False)
 
         # check ports for OVS services
-        self.LOGGER.logger("Checking OVS services ...", self.module, 3, 'checkOvsServicesPorts', False)
+        self.LOGGER.info("Checking OVS services ...", 'checkOvsServicesPorts', False)
         for sr in ServiceList.get_services():
             if sr.storagerouter_guid == self.machine_details.guid:
                 for port in sr.ports:
                     self._is_port_listening(sr.name, port)
 
         # check NGINX and memcached
-        self.LOGGER.logger("Checking NGINX and Memcached ...", self.module, 3, 'checkNginxAndMemcached', False)
+        self.LOGGER.info("Checking NGINX and Memcached ...", 'checkNginxAndMemcached', False)
 
         for process, ports in self.req_side_ports.iteritems():
             for port in ports:
                 self._is_port_listening(process, port)
 
         # Check Celery and RabbitMQ
-        self.LOGGER.logger("Checking RabbitMQ/Celery ...", self.module, 3, 'checkRabbitmqCelery', False)
+        self.LOGGER.info("Checking RabbitMQ/Celery ...", 'checkRabbitmqCelery', False)
 
         if self.utility.node_type == "MASTER":
             pcommand = "celery inspect ping -b amqp://ovs:0penv5tor4ge@{0}//".format(self.machine_details.ip)
             pcel = self.utility.execute_bash_command(pcommand.format(process))
             if len(pcel) != 1 and 'pong' in pcel[1].strip():
-                self.LOGGER.logger("Connection successfully established!", self.module, 1, 'port_celery')
+                self.LOGGER.success("Connection successfully established!", 'port_celery')
             else:
-                self.LOGGER.logger("Connection FAILED to service Celery, please check 'RabbitMQ' and 'ovs-workers'?",
-                                   self.module, 0, 'port_celery')
+                self.LOGGER.failure("Connection FAILED to service Celery, please check 'RabbitMQ' and 'ovs-workers'?",
+                                    'port_celery')
         else:
-            self.LOGGER.logger("RabbitMQ is not running/active on this server!", self.module, 5, 'port_celery')
+            self.LOGGER.skip("RabbitMQ is not running/active on this server!", 'port_celery')
 
     def check_ovs_packages(self):
         """
         Checks the availability of packages for Open vStorage
         """
 
-        self.LOGGER.logger("Checking OVS packages: ", self.module, 3, 'check_ovs_packages', False)
+        self.LOGGER.info("Checking OVS packages: ", 'check_ovs_packages', False)
 
         for package in self.openvstorageTotalPackageList:
             result = self.utility.execute_bash_command("apt-cache policy %s" % package)
             if len(result) != 1:
-                self.LOGGER.logger(
+                self.LOGGER.success(
                     "Package '%s' is present, with version '%s'" % (package, result[2].split(':')[1].strip()),
-                    self.module, 1, 'package_{0}'.format(package))
+                    'package_{0}'.format(package))
             else:
-                self.LOGGER.logger("Package '{0}' is NOT present ...".format(package), self.module, 5,
-                                   'package_{0}'.format(package))
+                self.LOGGER.skip("Package '{0}' is NOT present ...".format(package),
+                                 'package_{0}'.format(package))
         return None
 
     def check_ovs_processes(self):
@@ -385,21 +382,21 @@ class OpenvStorageHealthCheck:
         Checks the availability of processes for Open vStorage
         """
 
-        self.LOGGER.logger("Checking LOCAL OVS services: ", self.module, 3, 'check_ovs_processes', False)
+        self.LOGGER.info("Checking LOCAL OVS services: ", 'check_ovs_processes', False)
 
         if self.service_manager:
             for ovs_service in os.listdir("/etc/init"):
                 if ovs_service.startswith("ovs-"):
                     process_name = ovs_service.split(".conf", 1)[0].strip()
                     if self.utility.check_status_of_service(process_name):
-                        self.LOGGER.logger("Service '{0}' is running!".format(process_name), self.module, 1,
-                                           'process_{0}'.format(process_name))
+                        self.LOGGER.success("Service '{0}' is running!".format(process_name),
+                                            'process_{0}'.format(process_name))
                     else:
-                        self.LOGGER.logger("Service '{0}' is NOT running, please check this... ".format(process_name),
-                                           self.module, 0, 'process_{0}'.format(process_name))
+                        self.LOGGER.failure("Service '{0}' is NOT running, please check this... ".format(process_name),
+                                            'process_{0}'.format(process_name))
         else:
-            self.LOGGER.logger("Other service managers than 'init' are not yet supported!", self.module, 4,
-                               'hc_process_supported', False)
+            self.LOGGER.exception("Other service managers than 'init' are not yet supported!",
+                                  'hc_process_supported', False)
 
     def _method_handler(self, signum, frame):
         """
@@ -410,7 +407,7 @@ class OpenvStorageHealthCheck:
         """
 
         warning = "SPOTTED a PROCESS who is taking to long! Signum: {0} ; Frame {1}".format(signum, frame)
-        self.LOGGER.logger(warning, self.module, 3, 'spotted_idle_process', False)
+        self.LOGGER.info(warning, 'spotted_idle_process', False)
         raise Exception(warning)
 
     def _check_celery(self):
@@ -439,41 +436,41 @@ class OpenvStorageHealthCheck:
 
         rlogs = "'/var/log/rabbitmq/startup_*' or '/var/log/rabbitmq/shutdown_*'"
 
-        self.LOGGER.logger("Commencing deep check for celery/RabbitMQ", self.module, 2, '_extended_check_celery', False)
+        self.LOGGER.warning("Commencing deep check for celery/RabbitMQ", '_extended_check_celery', False)
 
         # check ovs-workers
         if not self.utility.check_status_of_service('ovs-workers'):
-            self.LOGGER.logger("Seems like ovs-workers are down, maybe due to RabbitMQ?", self.module, 0,
-                               'process_ovs-workers', False)
+            self.LOGGER.failure("Seems like ovs-workers are down, maybe due to RabbitMQ?",
+                                'process_ovs-workers', False)
             # check rabbitMQ status
             if self.utility.check_status_of_service('rabbitmq-server'):
                 # RabbitMQ seems to be DOWN
-                self.LOGGER.logger("RabbitMQ seems to be DOWN, please check logs in {0}".format(rlogs), self.module,
-                                   0, 'RabbitIsDown', False)
+                self.LOGGER.failure("RabbitMQ seems to be DOWN, please check logs in {0}".format(rlogs),
+                                    'RabbitIsDown', False)
                 return False
             else:
                 # RabbitMQ is showing it's up but lets check some more stuff
                 list_status = self.utility.execute_bash_command('rabbitmqctl list_queues')[1]
                 if "Error" in list_status:
-                    self.LOGGER.logger(
+                    self.LOGGER.failure(
                         "RabbitMQ seems to be UP but it is not functioning as it should! Maybe it has been"
                         " shutdown through 'stop_app'? Please check logs in {0}".format(
-                         rlogs), self.module, 0, 'RabbitSeemsUpButNotFunctioning', False)
+                         rlogs), 'RabbitSeemsUpButNotFunctioning', False)
                     return False
                 elif "Error: {aborted" in list_status:
-                    self.LOGGER.logger(
+                    self.LOGGER.failure(
                         "RabbitMQ seems to be DOWN but it is not functioning as it should! Please check logs in {0}"
-                        .format(rlogs), self.module, 0, 'RabbitSeemsDown', False)
+                        .format(rlogs), 'RabbitSeemsDown', False)
                     return False
                 else:
-                    self.LOGGER.logger("RabbitMQ process is running as it should, start checking the queues... ",
-                                       self.module, 1, 'checkQueuesButRabbitIsWorking', False)
+                    self.LOGGER.success("RabbitMQ process is running as it should, start checking the queues... ",
+                                        'checkQueuesButRabbitIsWorking', False)
         else:
-            self.LOGGER.logger("OVS workers are UP! Maybe it is stuck? Start checking the queues...", self.module, 0,
-                               'checkQueuesButOvsWorkersAreUp', False)
+            self.LOGGER.failure("OVS workers are UP! Maybe it is stuck? Start checking the queues...",
+                                'checkQueuesButOvsWorkersAreUp', False)
 
         # fetch remaining tasks on node
-        self.LOGGER.logger("Starting deep check for RabbitMQ!", self.module, 3, 'DeepCheckRabbit', False)
+        self.LOGGER.info("Starting deep check for RabbitMQ!", 'DeepCheckRabbit', False)
 
         #
         # Rabbitmq check: queue verification
@@ -490,24 +487,24 @@ class OpenvStorageHealthCheck:
             for i, j in zip(output_01, output_02):
                 if int(i) < int(j):
                     # queue is building up
-                    self.LOGGER.logger(
+                    self.LOGGER.warning(
                         "Seems like queue '{0}' is building up! Please verify this with 'rabbitmqctl list_queues "
-                        "| grep ovs_'".format(output_02.index(j)), self.module, 2, 'process_celery_queue_{0}'
+                        "| grep ovs_'".format(output_02.index(j)), 'process_celery_queue_{0}'
                         .format(output_02.index(j)), False)
                     lost_queues.append(output_02.index(j))
                 elif int(i) > int(j):
                     # queue is decreasing
-                    self.LOGGER.logger("Seems like queue '{0}' is working fine!".format(output_02.index(j)),
-                                       self.module, 1, 'process_celery_queue_{0}'.format(output_02.index(j)), False)
+                    self.LOGGER.success("Seems like queue '{0}' is working fine!".format(output_02.index(j)),
+                                        'process_celery_queue_{0}'.format(output_02.index(j)), False)
             # post-check
             if len(lost_queues) > 0:
                 return False
             else:
                 return True
         else:
-            self.LOGGER.logger(
+            self.LOGGER.failure(
                 "Seems like all Celery queues are stuck, you should check: 'rabbitmqctl list_queues' and 'ovs-workers'",
-                self.module, 0, 'process_celery_all_queues', False)
+                'process_celery_all_queues', False)
             return False
 
     def check_ovs_workers(self):
@@ -515,7 +512,7 @@ class OpenvStorageHealthCheck:
         Extended check of the Open vStorage workers; When the simple check fails, it will execute a full/deep check.
         """
 
-        self.LOGGER.logger("Checking if OVS-WORKERS are running smoothly: ", self.module, 3, 'check_ovs_workers', False)
+        self.LOGGER.info("Checking if OVS-WORKERS are running smoothly: ", 'check_ovs_workers', False)
 
         # init timout for x amount of sec for celery
         signal.signal(signal.SIGALRM, self._method_handler)
@@ -525,24 +522,24 @@ class OpenvStorageHealthCheck:
         try:
             # basic celery check
             self._check_celery()
-            self.LOGGER.logger("The OVS-WORKERS are working smoothly!", self.module, 1, 'process_celery')
+            self.LOGGER.success("The OVS-WORKERS are working smoothly!", 'process_celery')
         except Exception, ex:
             # kill alarm
             signal.alarm(0)
 
             # apparently the basic check failed, so we are going crazy
-            self.LOGGER.logger(
+            self.LOGGER.failure(
                 "Unexpected exception received during check of celery! Are RabbitMQ and/or ovs-workers running?"
-                " Traceback: {0}".format(ex), self.module, 0, 'process_celery')
+                " Traceback: {0}".format(ex), 'process_celery')
 
             # commencing deep check
             if not self._extended_check_celery():
-                self.LOGGER.logger("Please verify the integrety of 'RabbitMQ' and 'ovs-workers'", self.module, 0,
-                                   'CheckIntegrityOfWorkers', False)
+                self.LOGGER.failure("Please verify the integrety of 'RabbitMQ' and 'ovs-workers'",
+                                    'CheckIntegrityOfWorkers', False)
                 return False
             else:
-                self.LOGGER.logger("Deep check finished successfully but did not find anything... :(", self.module, 1,
-                                   'DeepCheckDidNotFindAnything', False)
+                self.LOGGER.success("Deep check finished successfully but did not find anything... :(",
+                                    'DeepCheckDidNotFindAnything', False)
                 return True
 
     def check_required_dirs(self):
@@ -550,28 +547,28 @@ class OpenvStorageHealthCheck:
         Checks the directories their rights and owners for mistakes
         """
 
-        self.LOGGER.logger("Checking if OWNERS are set correctly on certain maps: ", self.module, 3,
-                           'checkRequiredMaps_owners', False)
+        self.LOGGER.info("Checking if OWNERS are set correctly on certain maps: ",
+                         'checkRequiredMaps_owners', False)
         for dirname, owner_settings in self.req_map_owners.iteritems():
             if owner_settings.get('user') == self._get_owner_of_file(dirname) and owner_settings.get(
                     'group') == self._get_group_of_file(dirname):
-                self.LOGGER.logger("Directory '{0}' has correct owners!".format(dirname), self.module, 1,
-                                   'dir_{0}'.format(dirname))
+                self.LOGGER.success("Directory '{0}' has correct owners!".format(dirname),
+                                    'dir_{0}'.format(dirname))
             else:
-                self.LOGGER.logger(
+                self.LOGGER.failure(
                     "Directory '{0}' has INCORRECT owners! It must be OWNED by USER={1} and GROUP={2}"
                     .format(dirname, owner_settings.get('user'), owner_settings.get('group')),
-                    self.module, 0, 'dir_{0}'.format(dirname))
+                    'dir_{0}'.format(dirname))
 
-        self.LOGGER.logger("Checking if Rights are set correctly on certain maps: ", self.module, 3,
-                           'checkRequiredMaps_rights', False)
+        self.LOGGER.info("Checking if Rights are set correctly on certain maps: ",
+                         'checkRequiredMaps_rights', False)
         for dirname, rights in self.req_map_rights.iteritems():
             if self._check_rights_of_file(dirname, rights):
-                self.LOGGER.logger("Directory '{0}' has correct rights!".format(dirname), self.module, 1,
-                                   'dir_{0}'.format(dirname))
+                self.LOGGER.success("Directory '{0}' has correct rights!".format(dirname),
+                                    'dir_{0}'.format(dirname))
             else:
-                self.LOGGER.logger("Directory '{0}' has INCORRECT rights! It must be CHMOD={1} "
-                                   .format(dirname, rights), self.module, 0, 'dir_{0}'.format(dirname))
+                self.LOGGER.failure("Directory '{0}' has INCORRECT rights! It must be CHMOD={1} "
+                                    .format(dirname, rights), 'dir_{0}'.format(dirname))
 
         return True
 
@@ -640,15 +637,15 @@ class OpenvStorageHealthCheck:
         @rtype: bool
         """
 
-        self.LOGGER.logger("Checking DNS resolving: ", self.module, 3, 'titleDnsResolving', False)
+        self.LOGGER.info("Checking DNS resolving: ", 'titleDnsResolving', False)
         try:
             socket.gethostbyname(fqdn)
-            self.LOGGER.logger("DNS resolving works!", self.module, 1, 'dns_resolving')
+            self.LOGGER.success("DNS resolving works!", 'dns_resolving')
             return True
         except Exception:
-            self.LOGGER.logger("DNS resolving doesn't work, please check /etc/resolv.conf or add correct"
-                               " DNS server and make it immutable: 'sudo chattr +i /etc/resolv.conf'!",
-                               self.module, 0, 'dns_resolving')
+            self.LOGGER.failure("DNS resolving doesn't work, please check /etc/resolv.conf or add correct",
+                                "DNS server and make it immutable: 'sudo chattr +i /etc/resolv.conf'!",
+                                'dns_resolving')
             return False
 
     def get_zombied_and_dead_processes(self):
@@ -659,7 +656,7 @@ class OpenvStorageHealthCheck:
         zombie_processes = []
         dead_processes = []
 
-        self.LOGGER.logger("Checking for zombie/dead processes: ", self.module, 3, 'checkForZombieProcesses', False)
+        self.LOGGER.info("Checking for zombie/dead processes: ", 'checkForZombieProcesses', False)
 
         # check for zombie'd and dead processes
         for proc in psutil.process_iter():
@@ -676,17 +673,17 @@ class OpenvStorageHealthCheck:
 
         # check if there zombie processes
         if len(zombie_processes) == 0:
-            self.LOGGER.logger("There are NO zombie processes on this node!", self.module, 1, 'process_zombies')
+            self.LOGGER.success("There are NO zombie processes on this node!", 'process_zombies')
         else:
-            self.LOGGER.logger("We DETECTED zombie processes on this node: {0}".format(', '.join(zombie_processes)),
-                               self.module, 2, 'process_zombies')
+            self.LOGGER.warning("We DETECTED zombie processes on this node: {0}".format(', '.join(zombie_processes)),
+                                'process_zombies')
 
         # check if there dead processes
         if len(dead_processes) == 0:
-            self.LOGGER.logger("There are NO dead processes on this node!", self.module, 1, 'process_dead')
+            self.LOGGER.success("There are NO dead processes on this node!", 'process_dead')
         else:
-            self.LOGGER.logger("We DETECTED dead processes on this node: {0}".format(', '.join(dead_processes)),
-                               self.module, 0, 'process_dead')
+            self.LOGGER.failure("We DETECTED dead processes on this node: {0}".format(', '.join(dead_processes)),
+                                'process_dead')
 
     def _check_filedriver(self, args1, vp_name, test_name):
         """
@@ -712,8 +709,8 @@ class OpenvStorageHealthCheck:
             self.utility.execute_bash_command("touch /mnt/{0}/{1}.xml".format(vp_name, test_name))
             return True
         except Exception as e:
-            self.LOGGER.logger("Filedriver_check on vPool '{0}' got exception: {1}".format(vp_name, e), self.module, 6,
-                               'check_filedriver_{0}_thread_exception'.format(vp_name))
+            self.LOGGER.debug("Filedriver_check on vPool '{0}' got exception: {1}".format(vp_name, e),
+                              'check_filedriver_{0}_thread_exception'.format(vp_name))
             return False
 
     def _check_volumedriver(self, args1, vp_name, test_name):
@@ -741,8 +738,8 @@ class OpenvStorageHealthCheck:
                                     stderr=subprocess.STDOUT, shell=True)
             return True
         except Exception as e:
-            self.LOGGER.logger("Volumedriver_check on vPool '{0}' got exception: {1}".format(vp_name, e),
-                               self.module, 6, 'check_volumedriver_{0}_thread_exception'.format(vp_name))
+            self.LOGGER.debug("Volumedriver_check on vPool '{0}' got exception: {1}".format(vp_name, e),
+                              'check_volumedriver_{0}_thread_exception'.format(vp_name))
             return False
 
     def check_filedrivers(self):
@@ -753,7 +750,7 @@ class OpenvStorageHealthCheck:
         filedriversnotworking = []
         name = "ovs-healthcheck-test-{0}".format(self.machine_id)
 
-        self.LOGGER.logger("Checking filedrivers: ", self.module, 3, 'check_filedriver', False)
+        self.LOGGER.info("Checking filedrivers: ", 'check_filedriver', False)
 
         vpools = VPoolList.get_vpools()
 
@@ -779,13 +776,13 @@ class OpenvStorageHealthCheck:
 
             # check if filedrivers are OK!
             if len(filedriversnotworking) == 0:
-                self.LOGGER.logger("All filedrivers seem to be working fine!", self.module, 1, 'filedrivers')
+                self.LOGGER.success("All filedrivers seem to be working fine!", 'filedrivers')
             else:
-                self.LOGGER.logger("Some filedrivers seem to have some problems: {0}"
-                                   .format(', '.join(filedriversnotworking)), self.module, 0, 'filedrivers')
+                self.LOGGER.failure("Some filedrivers seem to have some problems: {0}"
+                                    .format(', '.join(filedriversnotworking)), 'filedrivers')
 
         else:
-            self.LOGGER.logger("No vPools found!", self.module, 5, 'filedrivers')
+            self.LOGGER.skip("No vPools found!", 'filedrivers')
 
     def check_volumedrivers(self):
         """
@@ -795,7 +792,7 @@ class OpenvStorageHealthCheck:
         volumedriversnotworking = []
         name = "ovs-healthcheck-test-{0}".format(self.machine_id)
 
-        self.LOGGER.logger("Checking volumedrivers: ", self.module, 3, 'check_volumedrivers', False)
+        self.LOGGER.info("Checking volumedrivers: ", 'check_volumedrivers', False)
 
         vpools = VPoolList.get_vpools()
 
@@ -820,27 +817,27 @@ class OpenvStorageHealthCheck:
 
             # check if filedrivers are OK!
             if len(volumedriversnotworking) == 0:
-                self.LOGGER.logger("All volumedrivers seem to be working fine!", self.module, 1, 'volumedrivers')
+                self.LOGGER.success("All volumedrivers seem to be working fine!", 'volumedrivers')
             else:
-                self.LOGGER.logger("Some volumedrivers seem to have some problems: {0}"
-                                   .format(', '.join(volumedriversnotworking)), self.module, 0, 'volumedrivers')
+                self.LOGGER.failure("Some volumedrivers seem to have some problems: {0}"
+                                    .format(', '.join(volumedriversnotworking)), 'volumedrivers')
 
         else:
-            self.LOGGER.logger("No vPools found!", self.module, 5, 'volumedrivers')
+            self.LOGGER.skip("No vPools found!", 'volumedrivers')
 
     def check_model_consistency(self):
         """
         Checks if the model consistency of OVSDB vs. VOLUMEDRIVER and does a preliminary check on RABBITMQ
         """
 
-        self.LOGGER.logger("Checking model consistency: ", self.module, 3, 'check_model_consistency', False)
+        self.LOGGER.info("Checking model consistency: ", 'check_model_consistency', False)
 
         #
         # RabbitMQ check: cluster verification
         #
 
-        self.LOGGER.logger("Precheck: verification of RabbitMQ cluster: ", self.module, 3,
-                           'checkRabbitMQcluster', False)
+        self.LOGGER.info("Precheck: verification of RabbitMQ cluster: ",
+                         'checkRabbitMQcluster', False)
 
         if self.utility.node_type == "MASTER":
 
@@ -856,18 +853,19 @@ class OpenvStorageHealthCheck:
 
                 # check parition status
                 if '@' in partition_status:
-                    self.LOGGER.logger("Seems like the RabbitMQ cluster has 'partition' problems, please check this...",
-                                       self.module, 0, 'process_rabbitmq', False)
+                    self.LOGGER.failure(
+                        "Seems like the RabbitMQ cluster has 'partition' problems, please check this...",
+                        'process_rabbitmq', False)
                 else:
-                    self.LOGGER.logger("RabbitMQ does not seem to have 'partition' problems", self.module, 1,
-                                       'process_rabbitmq', False)
+                    self.LOGGER.success("RabbitMQ does not seem to have 'partition' problems",
+                                        'process_rabbitmq', False)
             else:
-                self.LOGGER.logger("Seems like the RabbitMQ cluster has errors, maybe it is offline?", self.module, 0,
-                                   'process_rabbitmq', False)
+                self.LOGGER.failure("Seems like the RabbitMQ cluster has errors, maybe it is offline?",
+                                    'process_rabbitmq', False)
 
         else:
-            self.LOGGER.logger("RabbitMQ is not running/active on this server!", self.module, 5,
-                               'process_rabbitmq', False)
+            self.LOGGER.skip("RabbitMQ is not running/active on this server!",
+                             'process_rabbitmq', False)
 
         #
         # Checking consistency of volumedriver vs. ovsdb and backwards
@@ -875,8 +873,8 @@ class OpenvStorageHealthCheck:
 
         for vp in VPoolList.get_vpools():
 
-            self.LOGGER.logger("Checking consistency of volumedriver vs. ovsdb for vPool '{0}': ".format(vp.name),
-                               self.module, 3, 'checkDiscrepanciesVoldrvOvsdb', False)
+            self.LOGGER.info("Checking consistency of volumedriver vs. ovsdb for vPool '{0}': ".format(vp.name),
+                             'checkDiscrepanciesVoldrvOvsdb', False)
 
             # list of vdisks that are in model but are not in volumedriver
             missinginvolumedriver = []
@@ -907,27 +905,27 @@ class OpenvStorageHealthCheck:
 
             # display discrepancies for vPool
             if len(missinginvolumedriver) != 0:
-                self.LOGGER.logger("Detected volumes that are MISSING in volumedriver but ARE in ovsdb in vPool "
-                                   "'{0}': {1}".format(vp.name, ', '.join(missinginvolumedriver)), self.module, 0,
-                                   'discrepancies_ovsdb_{0}'.format(vp.name))
+                self.LOGGER.failure("Detected volumes that are MISSING in volumedriver but ARE in ovsdb in vPool "
+                                    "'{0}': {1}".format(vp.name, ', '.join(missinginvolumedriver)),
+                                    'discrepancies_ovsdb_{0}'.format(vp.name))
             else:
-                self.LOGGER.logger("NO discrepancies found for ovsdb in vPool '{0}'".format(vp.name), self.module, 1,
-                                   'discrepancies_ovsdb_{0}'.format(vp.name))
+                self.LOGGER.success("NO discrepancies found for ovsdb in vPool '{0}'".format(vp.name),
+                                    'discrepancies_ovsdb_{0}'.format(vp.name))
 
             if len(missinginmodel) != 0:
-                self.LOGGER.logger("Detected volumes that are AVAILABLE in volumedriver but ARE NOT in ovsdb in vPool "
-                                   "'{0}': {1}".format(vp.name, ', '.join(missinginmodel)), self.module, 0,
-                                   'discrepancies_voldrv_{0}'.format(vp.name))
+                self.LOGGER.failure("Detected volumes that are AVAILABLE in volumedriver but ARE NOT in ovsdb in vPool "
+                                    "'{0}': {1}".format(vp.name, ', '.join(missinginmodel)),
+                                    'discrepancies_voldrv_{0}'.format(vp.name))
             else:
-                self.LOGGER.logger("NO discrepancies found for voldrv in vPool '{0}'".format(vp.name), self.module, 1,
-                                   'discrepancies_voldrv_{0}'.format(vp.name))
+                self.LOGGER.success("NO discrepancies found for voldrv in vPool '{0}'".format(vp.name),
+                                    'discrepancies_voldrv_{0}'.format(vp.name))
 
     def check_for_halted_volumes(self):
         """
         Checks for halted volumes on a single or multiple vPools
         """
 
-        self.LOGGER.logger("Checking for halted volumes: ", self.module, 3, 'checkHaltedVolumes', False)
+        self.LOGGER.info("Checking for halted volumes: ", 'checkHaltedVolumes', False)
 
         vpools = VPoolList.get_vpools()
 
@@ -937,8 +935,8 @@ class OpenvStorageHealthCheck:
 
                 haltedvolumes = []
 
-                self.LOGGER.logger("Checking vPool '{0}': ".format(vp.name), self.module, 3,
-                                   'checkVPOOL_{0}'.format(vp.name), False)
+                self.LOGGER.info("Checking vPool '{0}': ".format(vp.name),
+                                 'checkVPOOL_{0}'.format(vp.name), False)
 
                 config_file = self.utility.get_config_file_path(vp.name, self.machine_id, 1, vp.guid)
                 voldrv_client = src.LocalStorageRouterClient(config_file)
@@ -958,13 +956,11 @@ class OpenvStorageHealthCheck:
 
                 # print all results
                 if len(haltedvolumes) > 0:
-                    self.LOGGER.logger("Detected volumes that are HALTED in volumedriver in vPool '{0}': {1}"
-                                       .format(vp.name, ', '.join(haltedvolumes)), self.module, 0,
-                                       'halted')
+                    self.LOGGER.failure("Detected volumes that are HALTED in volumedriver in vPool '{0}': {1}"
+                                        .format(vp.name, ', '.join(haltedvolumes)), 'halted')
                 else:
-                    self.LOGGER.logger("No halted volumes detected in vPool '{0}'"
-                                       .format(vp.name), self.module, 1,
-                                       'halted')
+                    self.LOGGER.success("No halted volumes detected in vPool '{0}'"
+                                        .format(vp.name), 'halted')
 
         else:
-            self.LOGGER.logger("No vPools found!".format(len(vpools)), self.module, 5, 'halted')
+            self.LOGGER.skip("No vPools found!".format(len(vpools)), 'halted')

--- a/ovs/lib/healthcheck.py
+++ b/ovs/lib/healthcheck.py
@@ -32,6 +32,7 @@ unattended = False
 silent_mode = False
 LOGGER = HCLogHandler(unattended, silent_mode)
 
+
 class HealthCheckController:
 
     @staticmethod
@@ -146,8 +147,8 @@ class HealthCheckController:
         Checks all critical components of Open vStorage
         """
 
-        LOGGER.logger("Starting Open vStorage Health Check!", module, 3, 'starting_ovs_hc', False)
-        LOGGER.logger("====================================\n", module, 3, 'starting_ovs_hc_ul', False)
+        LOGGER.info("Starting Open vStorage Health Check!", 'starting_ovs_hc', False)
+        LOGGER.info("====================================", 'starting_ovs_hc_ul', False)
 
         ovs = OpenvStorageHealthCheck(LOGGER)
 
@@ -201,8 +202,8 @@ class HealthCheckController:
         Checks all critical components of Arakoon
         """
 
-        LOGGER.logger("Starting Arakoon Health Check!", module, 3, 'starting_arakoon_hc', False)
-        LOGGER.logger("==============================\n", module, 3, 'starting_arakoon_hc_ul', False)
+        LOGGER.info("Starting Arakoon Health Check!", 'starting_arakoon_hc', False)
+        LOGGER.info("==============================", 'starting_arakoon_hc_ul', False)
 
         arakoon = ArakoonHealthCheck(LOGGER)
 
@@ -217,8 +218,8 @@ class HealthCheckController:
         Checks all critical components of Alba
         """
 
-        LOGGER.logger("Starting Alba Health Check!", module, 3, 'starting_alba_hc', False)
-        LOGGER.logger("===========================\n", module, 3, 'starting_alba_hc_ul', False)
+        LOGGER.info("Starting Alba Health Check!", 'starting_alba_hc', False)
+        LOGGER.info("===========================", 'starting_alba_hc_ul', False)
 
         alba = AlbaHealthCheck(LOGGER)
 
@@ -237,20 +238,20 @@ class HealthCheckController:
         @rtype: dict with nested dicts
         """
 
-        LOGGER.logger("Recap of Health Check!", module, 3, 'starting_recap_hc', False)
-        LOGGER.logger("======================\n", module, 3, 'starting_recap_hc_ul', False)
+        LOGGER.info("Recap of Health Check!", 'starting_recap_hc', False)
+        LOGGER.info("======================", 'starting_recap_hc_ul', False)
 
-        LOGGER.logger("SUCCESSFULL={0} FAILED={1} SKIPPED={2} WARNING={3} EXCEPTION={4}"
-                      .format(LOGGER.success, LOGGER.failure, LOGGER.skip, LOGGER.warning,
-                              LOGGER.exception), module, 1, 'exception_occured')
+        LOGGER.success("SUCCESSFULL={0} FAILED={1} SKIPPED={2} WARNING={3} EXCEPTION={4}"
+                       .format(LOGGER.HC_success, LOGGER.HC_failure, LOGGER.HC_skip, LOGGER.HC_warning,
+                               LOGGER.HC_exception), 'exception_occured')
 
         if silent_mode or unattended:
             # returns dict with minimal and detailed information
-            return {'result': LOGGER.healthcheck_dict, 'recap': {'SUCCESSFULL': LOGGER.success,
-                                                                 'FAILED': LOGGER.failure,
-                                                                 'SKIPPED': LOGGER.skip,
-                                                                 'WARNING': LOGGER.warning,
-                                                                 'EXCEPTION': LOGGER.exception}
+            return {'result': LOGGER.healthcheck_dict, 'recap': {'SUCCESSFULL': LOGGER.HC_success,
+                                                                 'FAILED': LOGGER.HC_failure,
+                                                                 'SKIPPED': LOGGER.HC_skip,
+                                                                 'WARNING': LOGGER.HC_warning,
+                                                                 'EXCEPTION': LOGGER.HC_exception}
                     }
         else:
             return None

--- a/ovs/lib/tests/healthcheck/scheduledtask_test.py
+++ b/ovs/lib/tests/healthcheck/scheduledtask_test.py
@@ -55,6 +55,7 @@ storagerouterclient.Logger.enableLogging()
 
 SCRUBBER_LOGFILE_LOCATION = '/var/log/upstart/ovs-scrubber.log'
 
+
 class ScheduledTaskController(object):
     """
     This controller contains all scheduled task code. These tasks can be

--- a/ovs/log/healthcheck_logHandler.py
+++ b/ovs/log/healthcheck_logHandler.py
@@ -20,10 +20,9 @@
 LogHandler module for OVS health check
 """
 
-import datetime
 import json
-import os
 from ovs.extensions.healthcheck.utils.extension import Utils
+from ovs.log.log_handler import LogHandler
 
 
 class _Colors:
@@ -69,8 +68,6 @@ class HCLogHandler:
             self.settings = json.load(settings_file)
 
         # fetch from config file
-        self.HEALTHCHECK_DIR = self.settings["healthcheck"]["logging"]["directory"]
-        self.HEALTHCHECK_FILE = self.settings["healthcheck"]["logging"]["file"]
         self.debug = self.settings["healthcheck"]["debug_mode"]
         self.enable = self.settings["healthcheck"]["logging"]["enable"]
 
@@ -84,172 +81,164 @@ class HCLogHandler:
             self.silent_mode = False
 
         # HC counters
-        self.failure = 0
-        self.success = 0
-        self.warning = 0
-        self.info = 0
-        self.exception = 0
-        self.skip = 0
-        self.debug = 0
+        self.HC_failure = 0
+        self.HC_success = 0
+        self.HC_warning = 0
+        self.HC_info = 0
+        self.HC_exception = 0
+        self.HC_skip = 0
+        self.HC_debug = 0
 
         # result of healthcheck in dict form
         self.healthcheck_dict = {}
 
-        # create if dir does not exists
-        if not os.path.isdir(self.HEALTHCHECK_DIR):
-            os.makedirs(self.HEALTHCHECK_DIR)
+        self._logger = LogHandler.get("healthcheck")
 
-    def logger(self, message, module, log_type, unattended_mode_name, unattended_print_mode=True):
+    def failure(self, msg, unattended_mode_name, unattended_print_mode=True):
         """
-        Logs the healthcheck output in a certain way chosen by the user
-
-        @param message: Log message for attended run
-        @param module: describes the module you are logging from
-        @param log_type: describes the log level
-            * failure = 0
-            * success = 1
-            * warning = 2
-            * info = 3
-            * exception = 4
-            * skip = 5
-            * debug = 6
-        @param unattended_mode_name: name for monitoring output
-        @param unattended_print_mode: describes if you want to print the output during a unattended run
-
-        @type message: str
-        @type module: str
-        @type log_type: int
-        @type unattended_print_mode: bool
-        @type unattended_mode_name: str
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
         """
-        target = ''
-        now = datetime.datetime.now()
+        if self.enable:
+            self._logger.error('FAILURE - {0}'.format(msg))
 
-        try:
-            if self.enable:
-                target = open('{0}/{1}'.format(self.HEALTHCHECK_DIR, self.HEALTHCHECK_FILE), 'a')
+        self.HC_failure += 1
 
-            if log_type == 0:
-                if self.enable:
-                    target.write("{0} - [FAILURE] - [{1}] - {2}\n".format(now, module, message))
-
-                self.failure += 1
-
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} FAILURE".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "FAILURE"
-                    else:
-                        print _Colors.FAIL + "[FAILURE] " + _Colors.ENDC + "%s" % (str(message))
-                else:
-                    if unattended_print_mode:
-                        self.healthcheck_dict[unattended_mode_name] = "FAILURE"
-
-            elif log_type == 1:
-                if self.enable:
-                    target.write("{0} - [SUCCESS] - [{1}] - {2}\n".format(now, module, message))
-                self.success += 1
-
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} SUCCESS".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "SUCCESS"
-                    else:
-                        print _Colors.OKGREEN + "[SUCCESS] " + _Colors.ENDC + "%s" % (str(message))
-                else:
-                    if unattended_print_mode:
-                        self.healthcheck_dict[unattended_mode_name] = "SUCCESS"
-
-            elif log_type == 2:
-                if self.enable:
-                    target.write("{0} - [WARNING] - [{1}] - {2}\n".format(now, module, message))
-                self.warning += 1
-
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} WARNING".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "WARNING"
-                    else:
-                        print _Colors.WARNING + "[WARNING] " + _Colors.ENDC + "%s" % (str(message))
-                else:
-                    if unattended_print_mode:
-                        self.healthcheck_dict[unattended_mode_name] = "WARNING"
-
-            elif log_type == 3:
-                if self.enable:
-                    target.write("{0} - [INFO] - [{1}] - {2}\n".format(now, module, message))
-                self.info += 1
-
-                # info_mode is NOT logged silently
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} INFO".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "INFO"
-                    else:
-                        print _Colors.OKBLUE + "[INFO] " + _Colors.ENDC + "%s" % (str(message))
-
-            elif log_type == 4:
-                if self.enable:
-                    target.write("{0} - [EXCEPTION] - [{1}] - {2}\n".format(now, module, message))
-                self.exception += 1
-
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} EXCEPTION".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "EXCEPTION"
-                    else:
-                        print _Colors.FAIL + "[EXCEPTION] " + _Colors.ENDC + "%s" % (str(message))
-                else:
-                    if unattended_print_mode:
-                        self.healthcheck_dict[unattended_mode_name] = "EXCEPTION"
-
-            elif log_type == 5:
-                if self.enable:
-                    target.write("{0} - [SKIPPED] - [{1}] - {2}\n".format(now, module, message))
-                self.skip += 1
-
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} SKIPPED".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "SKIPPED"
-                    else:
-                        print _Colors.SKIP + "[SKIPPED] " + _Colors.ENDC + "%s" % (str(message))
-                else:
-                    if unattended_print_mode:
-                        self.healthcheck_dict[unattended_mode_name] = "SKIPPED"
-
-            elif log_type == 6:
-                if self.debug:
-                    if self.enable:
-                        target.write("{0} - [DEBUG] - [{1}] - {2}\n".format(now, module, message))
-                    self.debug += 1
-                    print _Colors.OKBLUE + "[DEBUG] " + _Colors.ENDC + "%s" % (str(message))
-                    self.healthcheck_dict[unattended_mode_name] = "DEBUG"
-
+        if not self.silent_mode:
+            if self.unattended_mode:
+                if unattended_print_mode:
+                    print "{0} FAILURE".format(unattended_mode_name)
+                    self.healthcheck_dict[unattended_mode_name] = "FAILURE"
             else:
-                if self.enable:
-                    target.write("{0} - [UNEXPECTED_EXCEPTION] - [{1}] - {2}\n".format(now, module, message))
-                self.exception += 1
+                print _Colors.FAIL + "[FAILURE] " + _Colors.ENDC + "%s" % (str(msg))
+        else:
+            if unattended_print_mode:
+                self.healthcheck_dict[unattended_mode_name] = "FAILURE"
 
-                if not self.silent_mode:
-                    if self.unattended_mode:
-                        if unattended_print_mode:
-                            print "{0} UNEXPECTED_EXCEPTION".format(unattended_mode_name)
-                            self.healthcheck_dict[unattended_mode_name] = "UNEXPECTED_EXCEPTION"
-                    else:
-                        print _Colors.FAIL + "[UNEXPECTED_EXCEPTION] " + _Colors.ENDC + "%s" % (str(message))
-                else:
-                    if unattended_print_mode:
-                        self.healthcheck_dict[unattended_mode_name] = "UNEXPECTED_EXCEPTION"
+    def success(self, msg, unattended_mode_name, unattended_print_mode=True):
+        """
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
+        """
+        if self.enable:
+            self._logger.info('SUCCESS - {0}'.format(msg))
+        self.HC_success += 1
 
+        if not self.silent_mode:
+            if self.unattended_mode:
+                if unattended_print_mode:
+                    print "{0} SUCCESS".format(unattended_mode_name)
+                    self.healthcheck_dict[unattended_mode_name] = "SUCCESS"
+            else:
+                print _Colors.OKGREEN + "[SUCCESS] " + _Colors.ENDC + "%s" % (str(msg))
+        else:
+            if unattended_print_mode:
+                self.healthcheck_dict[unattended_mode_name] = "SUCCESS"
+
+    def warning(self, msg, unattended_mode_name, unattended_print_mode=True):
+        """
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
+        """
+        if self.enable:
+            self._logger.warning('{0}'.format(msg))
+        self.HC_warning += 1
+
+        if not self.silent_mode:
+            if self.unattended_mode:
+                if unattended_print_mode:
+                    print "{0} WARNING".format(unattended_mode_name)
+                    self.healthcheck_dict[unattended_mode_name] = "WARNING"
+            else:
+                print _Colors.WARNING + "[WARNING] " + _Colors.ENDC + "%s" % (str(msg))
+        else:
+            if unattended_print_mode:
+                self.healthcheck_dict[unattended_mode_name] = "WARNING"
+
+    def info(self, msg, unattended_mode_name, unattended_print_mode=True):
+        """
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
+        """
+        if self.enable:
+            self._logger.info('{0}'.format(msg))
+        self.HC_info += 1
+
+        # info_mode is NOT logged silently
+        if not self.silent_mode:
+            if self.unattended_mode:
+                if unattended_print_mode:
+                    print "{0} INFO".format(unattended_mode_name)
+                    self.healthcheck_dict[unattended_mode_name] = "INFO"
+            else:
+                print _Colors.OKBLUE + "[INFO] " + _Colors.ENDC + "%s" % (str(msg))
+
+    def exception(self, msg, unattended_mode_name, unattended_print_mode=True):
+        """
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
+        """
+        if self.enable:
+            self._logger.exception('EXCEPTION - {0}'.format(msg))
+        self.HC_exception += 1
+
+        if not self.silent_mode:
+            if self.unattended_mode:
+                if unattended_print_mode:
+                    print "{0} EXCEPTION".format(unattended_mode_name)
+                    self.healthcheck_dict[unattended_mode_name] = "EXCEPTION"
+            else:
+                print _Colors.FAIL + "[EXCEPTION] " + _Colors.ENDC + "%s" % (str(msg))
+        else:
+            if unattended_print_mode:
+                self.healthcheck_dict[unattended_mode_name] = "EXCEPTION"
+
+    def skip(self, msg, unattended_mode_name, unattended_print_mode=True):
+        """
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
+        """
+        if self.enable:
+            self._logger.info('SKIPPED - {0}'.format(msg))
+        self.HC_skip += 1
+
+        if not self.silent_mode:
+            if self.unattended_mode:
+                if unattended_print_mode:
+                    print "{0} SKIPPED".format(unattended_mode_name)
+                    self.healthcheck_dict[unattended_mode_name] = "SKIPPED"
+            else:
+                print _Colors.SKIP + "[SKIPPED] " + _Colors.ENDC + "%s" % (str(msg))
+
+    def debug(self, msg, unattended_mode_name, unattended_print_mode=True):
+        """
+        :param msg: Log message for attended run
+        :param unattended_mode_name: name for monitoring output
+        :param unattended_print_mode: describes if you want to print the output during a unattended run
+        :param module: describes the module you are logging from
+        :return:
+        """
+        if self.debug:
             if self.enable:
-                target.close()
-
-        except Exception, e:
-            print "An unexpected exception occured during logging in '{0}': \n{1}".format(self.HEALTHCHECK_DIR, e)
+                self._logger.debug('{0}'.format(msg))
+            self.HC_debug += 1
+            print _Colors.OKBLUE + "[DEBUG] " + _Colors.ENDC + "%s" % (str(msg))
+            self.healthcheck_dict[unattended_mode_name] = "DEBUG"


### PR DESCRIPTION
Using the standard ovs log format described [here](https://openvstorage.gitbooks.io/framework/content/docs/log.html).

example:
```
2016-06-15 09:03:51 99500 +0200 - cmp01 - 2580/140283832026944 - healthcheck/logger - 117 - INFO - ===========================
2016-06-15 09:03:52 08700 +0200 - cmp01 - 2580/140283832026944 - healthcheck/logger - 118 - INFO - Fetching all Available ALBA backends ...
2016-06-15 09:03:52 09000 +0200 - cmp01 - 2580/140283832026944 - healthcheck/logger - 119 - ERROR - FAILURE - One ore more Arakoon clusters cannot be reached due to error: 'AlbaBackend' object has no attribute 'all_disks'
2016-06-15 09:03:52 09100 +0200 - cmp01 - 2580/140283832026944 - healthcheck/logger - 120 - INFO - Recap of Health Check!
2016-06-15 09:03:52 09100 +0200 - cmp01 - 2580/140283832026944 - healthcheck/logger - 121 - INFO - ======================
2016-06-15 09:03:52 09100 +0200 - cmp01 - 2580/140283832026944 - healthcheck/logger - 122 - INFO - SUCCESS - SUCCESSFULL=72 FAILED=1 SKIPPED=5 WARNING=0 EXCEPTION=0
```