### PR TITLE
Using timeout_decorator instead of signal.alarm

### DIFF
--- a/bin/post-install.sh
+++ b/bin/post-install.sh
@@ -23,3 +23,4 @@ wget https://bootstrap.pypa.io/get-pip.py; python get-pip.py
 pip install flower
 pip install psutil
 pip install xmltodict
+pip install timeout-decorator


### PR DESCRIPTION
pip install timeout-decorator added to post-install script.

output when ovs-workers is down or stuck:

```
[FAILURE] Unexpected exception received during check of celery! Are RabbitMQ and/or ovs-workers running? Traceback: 'Timed Out: Process is taking to long!'
```