### PR TITLE
false alarm on collapse check

### DIFF
--- a/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
+++ b/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
@@ -248,7 +248,10 @@ class ArakoonHealthCheck:
                              if tlx_file.endswith('.tlx')]
                 amount_tlx = len(tlx_files)
 
-                if amount_tlx == 0:
+                if amount_tlx == 0 and len([tlog_file for tlog_file in files if tlog_file.endswith('.tlog')]) > 0:
+                    result['OK'].append(arakoon)
+                    continue
+                elif amount_tlx == 0 and len([tlog_file for tlog_file in files if tlog_file.endswith('.tlog')]) < 0:
                     result['NOK'].append(arakoon)
                     if not self.LOGGER.unattended_mode:
                         self.LOGGER.failure("No tlx files found and head.db is out of sync "


### PR DESCRIPTION
when deploying a new arakoon, there are no tlx files and throws an error --> check first if there is a tlog file if so no issue if not throw an error.

from the moment there is one tlx file, the check will proceed with checking the timestamp from the oldest tlx file.