### PR TITLE
Hc 145 do not list empty lists

### DIFF
--- a/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
+++ b/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
@@ -418,7 +418,10 @@ class ArakoonHealthCheck(object):
 
         arakoon_clusters, missing_nodes = ArakoonHealthCheck.fetch_clusters(logger)
         if len([nodes for nodes in missing_nodes.itervalues() if len(nodes) != 0]) != 0:
-            logger.failure("The following nodes are stored in arakoon but missing in reality: {0}".format(missing_nodes.items()), 'nodes_missing')
+            # Only return the (arakoon, system id) tuple for arakoons that have missing system ids
+            missing = [cluster for cluster in missing_nodes.items() if len(cluster[1]) != 0]
+            logger.failure("The following nodes are stored in arakoon but missing in reality (output format is "
+                           "(arakoon, [system ids]): {0}".format(missing), 'nodes_missing')
         else:
             logger.success("Found no nodes that are missing according to arakoons.", "nodes_missing")
         if len(arakoon_clusters.keys()) != 0:

--- a/ovs/extensions/healthcheck/volumedriver/volumedriver_health_check.py
+++ b/ovs/extensions/healthcheck/volumedriver/volumedriver_health_check.py
@@ -142,10 +142,10 @@ class VolumedriverHealthCheck(object):
                         # timeout occured, action took too long
                         logger.failure("Volumedriver of vPool '{0}' seems to have `timeout` problems"
                                        .format(vp.name), 'volumedriver_{0}'.format(vp.name))
-                    except IOError:
+                    except IOError as ex:
                         # can be input/output error by volumedriver
-                        logger.failure("Volumedriver of vPool '{0}' seems to have `input/output` problems"
-                                       .format(vp.name), 'volumedriver_{0}'.format(vp.name))
+                        logger.failure("Volumedriver of vPool '{0}' seems to have `input/output` problems. Got {1} while executing."
+                                       .format(vp.name, ex), 'volumedriver_{0}'.format(vp.name))
                     except ValueError as ex:
                         logger.failure(ex, 'volumedriver_{0}'.format(vp.name))
 


### PR DESCRIPTION
Changes demo:
```
test = {}
for i in xrange(0,11):
 l = []
 if i % 2 == 0:
  for j in xrange(0,i):
   l.append(j)
 test["test{}".format(i)]= l

if len([nodes for nodes in test.itervalues() if len(nodes) != 0]) != 0:
 missing = [cluster for cluster in test.items() if len(cluster[1]) != 0]
 print "old output: {0}".format(test.items())
 print "new output: {0}".format(missing)
 
```
```
old output: [('test1', []), ('test0', []), ('test3', []), ('test2', [0, 1]), ('test5', []), ('test4', [0, 1, 2, 3]), ('test7', []), ('test6', [0, 1, 2, 3, 4, 5]), ('test9', []), ('test8', [0, 1, 2, 3, 4, 5, 6, 7]), ('test10', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])]
new output: [('test2', [0, 1]), ('test4', [0, 1, 2, 3]), ('test6', [0, 1, 2, 3, 4, 5]), ('test8', [0, 1, 2, 3, 4, 5, 6, 7]), ('test10', [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])]
```