### PR TITLE
Check restarts logging

### DIFF
--- a/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
+++ b/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
@@ -200,6 +200,14 @@ class ArakoonHealthCheck(object):
 
             result['OK'].append(cluster_name)
 
+        if len(result['NOK']) > 0:
+            logger.failure("{0} Arakoon(s) restarted more than {1} times in {2} minutes: {3}"
+                           .format(len(result['NOK']),
+                                   ArakoonHealthCheck.MAX_AMOUNT_NODE_RESTARTED,
+                                   ArakoonHealthCheck.LAST_MINUTES,
+                                   ','.join(result['NOK'])), 'arakoon_restarts')
+        elif len(result['OK']) > 0:
+            logger.success("ALL Arakoon(s) restart check(s) is/are OK!", 'arakoon_restarts')
         return result
 
     @staticmethod
@@ -427,11 +435,6 @@ class ArakoonHealthCheck(object):
         if len(arakoon_clusters.keys()) != 0:
             logger.success("{0} available Arakoons successfully fetched, starting verification of clusters ..."
                            .format(len(arakoon_clusters)), 'arakoon_found')
-
-            ArakoonHealthCheck.check_collapse(logger=logger, arakoon_clusters=arakoon_clusters)
-            ArakoonHealthCheck.verify_integrity(logger=logger, arakoon_clusters=arakoon_clusters)
-            ArakoonHealthCheck.check_restarts(logger=logger, arakoon_clusters=arakoon_clusters)
-
         else:
             logger.skip("No available clusters found", 'arakoon_found')
 
@@ -445,3 +448,6 @@ class ArakoonHealthCheck(object):
         """
         ArakoonHealthCheck.check_required_ports(logger)
         ArakoonHealthCheck.check_arakoons(logger)
+        ArakoonHealthCheck.check_collapse(logger)
+        ArakoonHealthCheck.verify_integrity(logger)
+        ArakoonHealthCheck.check_restarts(logger)

--- a/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
+++ b/ovs/extensions/healthcheck/arakoon/arakooncluster_health_check.py
@@ -225,6 +225,8 @@ class ArakoonHealthCheck(object):
         :return: list with OK, NOK status
         :rtype: list
         """
+        if arakoon_clusters is None:
+            arakoon_clusters = ArakoonHealthCheck.fetch_clusters(logger)[0]
 
         result = {"OK": [], "NOK": []}
         # tlx file must have young timestamp than this one.


### PR DESCRIPTION
Changes:
CC @jeroenmaelbrancke 
Arakoon restart-test:
old
```
root@ovs-node-1:~# ovs healthcheck arakoon restart-test
[INFO] Fetching available arakoon clusters.
[INFO] Recap of arakoon restart-test!
[INFO] ======================
[INFO] SUCCESS=0 FAILED=0 SKIPPED=0 WARNING=0 EXCEPTION=0
```

new
```
root@ovs-node-1:~# ovs healthcheck arakoon restart-test
[INFO] Fetching available arakoon clusters.
[SUCCESS] ALL Arakoon(s) restart check(s) is/are OK!
[INFO] Recap of arakoon restart-test!
[INFO] ======================
[INFO] SUCCESS=1 FAILED=0 SKIPPED=0 WARNING=0 EXCEPTION=0
```
check-arakoons
This test now only checks if the arakoons are found and also the node information found within the arakoons.
All nodes that are not present in reality but are stored in Arakoon will make the test missing_nodes fail
If arakoons are found it will pass success to arakoon_found

Example:
```
root@ovs-node-1:~# ovs healthcheck arakoon check-arakoons
[INFO] Fetching available arakoon clusters.
[SUCCESS] Found no nodes that are missing according to arakoons.
[SUCCESS] 4 available Arakoons successfully fetched, starting verification of clusters ...
[INFO] Recap of arakoon check-arakoons!
[INFO] ======================
[INFO] SUCCESS=2 FAILED=0 SKIPPED=0 WARNING=0 EXCEPTION=0
root@ovs-node-1:~# ovs healthcheck arakoon check-arakoons unattended
arakoon_found SUCCESS
nodes_missing SUCCESS
root@ovs-node-1:~# 

```
