### PR TITLE
disable volumedriver check for volumes

### DIFF
--- a/ovs/extensions/healthcheck/volumedriver/volumedriver_health_check.py
+++ b/ovs/extensions/healthcheck/volumedriver/volumedriver_health_check.py
@@ -377,6 +377,6 @@ class VolumedriverHealthCheck(object):
         :rtype: NoneType
         """
         VolumedriverHealthCheck.check_dtl(logger)
-        VolumedriverHealthCheck.check_volumedrivers(logger)
+        # VolumedriverHealthCheck.check_volumedrivers(logger)
         VolumedriverHealthCheck.check_for_halted_volumes(logger)
         VolumedriverHealthCheck.check_filedrivers(logger)


### PR DESCRIPTION
Remove volumedriver testing via volume deployment
https://github.com/openvstorage/openvstorage-health-check/issues/259