### PR TITLE
Remove checking for unstable or fargo branch 

### DIFF
--- a/ovs/extensions/healthcheck/helpers/helper.py
+++ b/ovs/extensions/healthcheck/helpers/helper.py
@@ -77,15 +77,14 @@ class Helper(object):
                           'hostname': socket.gethostname(),
                           'storagerouter_id': Helper.LOCAL_ID,
                           'storagerouter_type': Helper.LOCAL_SR.node_type,
-                          'environment_release': ovs_version[0],
-                          'environment_branch': ovs_version[1].title(),
+                          'environment_release': ovs_version,
                           'environment os': ' '.join(platform.linux_distribution())}
         return local_settings
 
     @staticmethod
     def get_ovs_version():
         """
-        Gets the RELEASE & BRANCH of the Open vStorage cluster
+        Gets the RELEASE Open vStorage cluster
         :return: RELEASE & BRANCH of openvstorage cluster
         :rtype: tuple
         """
@@ -93,10 +92,7 @@ class Helper(object):
         with open("/opt/OpenvStorage/webapps/frontend/locales/en-US/ovs.json") as ovs_json:
             ovs_releasename = json.load(ovs_json)["support"]["release_name"]
 
-        with open("/etc/apt/sources.list.d/ovsaptrepo.list") as ovs_json:
-            ovs_current_version = ovs_json.read().split()[2]
-
-        return ovs_releasename, ovs_current_version
+        return ovs_releasename
 
     @staticmethod
     def check_status_of_service(service_name):

--- a/ovs/extensions/healthcheck/helpers/helper.py
+++ b/ovs/extensions/healthcheck/helpers/helper.py
@@ -84,9 +84,9 @@ class Helper(object):
     @staticmethod
     def get_ovs_release_name():
         """
-        Gets the RELEASE Open vStorage cluster
-        :return: RELEASE openvstorage cluster
-        :rtype: string
+        Gets the RELEASE of Open vStorage cluster
+        :return: RELEASE of openvstorage cluster
+        :rtype: str
         """
         release_name = 'Unknown'
         # This file should always exist if ovs is installed. Without it, the GUI should not work

--- a/ovs/extensions/healthcheck/helpers/helper.py
+++ b/ovs/extensions/healthcheck/helpers/helper.py
@@ -21,6 +21,7 @@ Helper module
 """
 import json
 import platform
+import os
 import socket
 import subprocess
 from ovs.extensions.generic.system import System
@@ -71,28 +72,30 @@ class Helper(object):
         :return: local settings of the node
         :rtype: dict
         """
-        ovs_version = Helper.get_ovs_version()
         # Fetch all details
         local_settings = {'cluster_id': Configuration.get("/ovs/framework/cluster_id"),
                           'hostname': socket.gethostname(),
                           'storagerouter_id': Helper.LOCAL_ID,
                           'storagerouter_type': Helper.LOCAL_SR.node_type,
-                          'environment_release': ovs_version,
+                          'environment_release': Helper.get_ovs_release_name(),
                           'environment os': ' '.join(platform.linux_distribution())}
         return local_settings
 
     @staticmethod
-    def get_ovs_version():
+    def get_ovs_release_name():
         """
         Gets the RELEASE Open vStorage cluster
-        :return: RELEASE & BRANCH of openvstorage cluster
-        :rtype: tuple
+        :return: RELEASE openvstorage cluster
+        :rtype: string
         """
+        release_name = 'Unknown'
+        # This file should always exist if ovs is installed. Without it, the GUI should not work
+        file_loc = '/opt/OpenvStorage/webapps/frontend/locales/en-US/ovs.json'
+        if os.path.isfile(file_loc):
+            with open(file_loc) as ovs_json:
+                release_name = json.load(ovs_json)["support"]["release_name"]
 
-        with open("/opt/OpenvStorage/webapps/frontend/locales/en-US/ovs.json") as ovs_json:
-            ovs_releasename = json.load(ovs_json)["support"]["release_name"]
-
-        return ovs_releasename
+        return release_name
 
     @staticmethod
     def check_status_of_service(service_name):


### PR DESCRIPTION
due to issues when the file is not present. This information can still be deducted due to the reporting of what HC version is running.
https://github.com/openvstorage/openvstorage-health-check/issues/250