### PR TITLE
Made CLI dummyproof

### DIFF
--- a/ovs/extensions/healthcheck/expose_to_cli.py
+++ b/ovs/extensions/healthcheck/expose_to_cli.py
@@ -221,6 +221,7 @@ class CLIRunner(object):
         elif len(method_pointers) == 1:
             # Found only one method -> search term was module_name + method_name
             print method_pointers[0].__doc__
+            return
         print 'Possible optional arguments are:'
         # Multiple entries found means only the module_name was supplied
         print 'ovs healthcheck {0} {0} -- will run all checks'.format(CLIRunner._WILDCARD)


### PR DESCRIPTION
- https://github.com/openvstorage/openvstorage-health-check/issues/281
```
root@ovs-node01-1604:~# ovs healthcheck gibberish
Could not process your arguments.
Possible optional arguments are:
ovs healthcheck X X -- will run all checks
ovs healthcheck MODULE X -- will run all checks for module
ovs healthcheck volumedriver dtl-test
ovs healthcheck volumedriver halted-volumes-test
ovs healthcheck volumedriver dtl-test
ovs healthcheck volumedriver halted-volumes-test
ovs healthcheck ovs dns-test
ovs healthcheck ovs memcached-ports-test
ovs healthcheck ovs model-test
ovs healthcheck ovs nginx-ports-test
ovs healthcheck ovs packages-test
ovs healthcheck ovs processes-test
ovs healthcheck ovs workers-test
ovs healthcheck ovs celery-ports-test
ovs healthcheck ovs directories-test
ovs healthcheck ovs log-files-test
ovs healthcheck ovs zombie-processes-test
ovs healthcheck ovs verify-rabbitmq-test
ovs healthcheck ovs dns-test
ovs healthcheck ovs memcached-ports-test
ovs healthcheck ovs model-test
ovs healthcheck ovs nginx-ports-test
ovs healthcheck ovs packages-test
ovs healthcheck ovs processes-test
ovs healthcheck ovs workers-test
ovs healthcheck ovs celery-ports-test
ovs healthcheck ovs directories-test
ovs healthcheck ovs log-files-test
ovs healthcheck ovs zombie-processes-test
ovs healthcheck ovs verify-rabbitmq-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck arakoon collapse-test
ovs healthcheck arakoon ports-test
ovs healthcheck arakoon missing-node-test
ovs healthcheck arakoon consistency-test
ovs healthcheck arakoon integrity-test
ovs healthcheck arakoon collapse-test
ovs healthcheck arakoon ports-test
ovs healthcheck arakoon missing-node-test
ovs healthcheck arakoon consistency-test
ovs healthcheck arakoon integrity-test

```
```
root@ovs-node01-1604:~# ovs healthcheck alba gibberish
Could not process your arguments.
Possible optional arguments are:
ovs healthcheck X X -- will run all checks
ovs healthcheck MODULE X -- will run all checks for module
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
root@ovs-node01-1604:~# 

```
root@ovs-node01-1604:~# ovs healthcheck gibberish gibberis
Could not process your arguments.
Possible optional arguments are:
ovs healthcheck X X -- will run all checks
ovs healthcheck MODULE X -- will run all checks for module
ovs healthcheck volumedriver dtl-test
ovs healthcheck volumedriver halted-volumes-test
ovs healthcheck volumedriver dtl-test
ovs healthcheck volumedriver halted-volumes-test
ovs healthcheck ovs dns-test
ovs healthcheck ovs memcached-ports-test
ovs healthcheck ovs model-test
ovs healthcheck ovs nginx-ports-test
ovs healthcheck ovs packages-test
ovs healthcheck ovs processes-test
ovs healthcheck ovs workers-test
ovs healthcheck ovs celery-ports-test
ovs healthcheck ovs directories-test
ovs healthcheck ovs log-files-test
ovs healthcheck ovs zombie-processes-test
ovs healthcheck ovs verify-rabbitmq-test
ovs healthcheck ovs dns-test
ovs healthcheck ovs memcached-ports-test
ovs healthcheck ovs model-test
ovs healthcheck ovs nginx-ports-test
ovs healthcheck ovs packages-test
ovs healthcheck ovs processes-test
ovs healthcheck ovs workers-test
ovs healthcheck ovs celery-ports-test
ovs healthcheck ovs directories-test
ovs healthcheck ovs log-files-test
ovs healthcheck ovs zombie-processes-test
ovs healthcheck ovs verify-rabbitmq-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck alba processes-test
ovs healthcheck alba proxy-port-test
ovs healthcheck alba backend-test
ovs healthcheck alba disk-safety-test
ovs healthcheck alba proxy-test
ovs healthcheck arakoon collapse-test
ovs healthcheck arakoon ports-test
ovs healthcheck arakoon missing-node-test
ovs healthcheck arakoon consistency-test
ovs healthcheck arakoon integrity-test
ovs healthcheck arakoon collapse-test
ovs healthcheck arakoon ports-test
ovs healthcheck arakoon missing-node-test
ovs healthcheck arakoon consistency-test
ovs healthcheck arakoon integrity-test

```

